### PR TITLE
Add GitHub workflow commit logging rule

### DIFF
--- a/docs/GITHUB_WORKFLOWS.md
+++ b/docs/GITHUB_WORKFLOWS.md
@@ -51,8 +51,8 @@ rules:
     # Optionally require workflows to commit logs to the branch
     require-log-commits: false
 
-    # Optionally require workflows to upload log artifacts
-    require-log-artifacts: false
+    # Optionally require workflows to package codebase with repomix and upload as artifact
+    require-repomix-artifact: false
 
     # Optionally require specific jobs
     required-jobs:
@@ -243,21 +243,25 @@ jobs:
           git push
 ```
 
-### 9. Log Artifact Uploads
+### 9. Repomix Codebase Artifact
 
-Optionally require workflows to upload execution logs as artifacts (alternative or complement to log commits):
+Optionally require workflows to package the codebase with repomix and upload as an artifact for agent context:
 
 ```yaml
 rules:
   github-workflows:
-    require-log-artifacts: true  # Require workflows to upload log artifacts
+    require-repomix-artifact: true  # Require workflows to upload repomix codebase summary
 ```
+
+This ensures workflows:
+- Run repomix to create a comprehensive codebase summary
+- Upload the repomix output as an artifact for agent analysis
 
 **Violation**:
 ```
-.github/workflows/test.yml: Job 'test' missing log artifact upload steps.
-Add 'actions/upload-artifact' steps to preserve execution logs.
-Example: use 'actions/upload-artifact@v4' with log file paths.
+.github/workflows/test.yml: Job 'test' missing repomix artifact steps.
+Add steps to run repomix and upload the codebase summary as an artifact for agent context.
+Example: run 'npx repomix' and use 'actions/upload-artifact@v4' to upload the output.
 ```
 
 **Valid Example**:
@@ -270,19 +274,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
-        run: go test ./... 2>&1 | tee test.log
-      - name: Upload logs on failure
-        if: failure()
+        run: go test ./...
+      - name: Generate repomix summary
+        run: npx repomix
+      - name: Upload repomix artifact
         uses: actions/upload-artifact@v4
         with:
-          name: test-logs-${{ runner.os }}
-          path: test.log
+          name: repomix-output-${{ github.sha }}
+          path: repomix-output.txt
           retention-days: 7
 ```
 
-**Note**: You can enable both `require-log-commits` and `require-log-artifacts` for comprehensive logging:
-- Log commits allow automated agents to pull and review results
-- Log artifacts provide GitHub UI access and retention management
+**Note**: Repomix creates a comprehensive codebase summary that agents can use to understand the full context of your project, making it easier for automated tools to analyze failures and suggest fixes.
 
 ## Example Workflows
 

--- a/examples/github-workflows/.structurelint.yml
+++ b/examples/github-workflows/.structurelint.yml
@@ -24,9 +24,9 @@ rules:
     # Allows agents to pull and review execution results
     # require-log-commits: true
 
-    # Optionally require workflows to upload log artifacts
-    # Provides GitHub UI access to execution logs
-    # require-log-artifacts: true
+    # Optionally require workflows to package codebase with repomix and upload as artifact
+    # Provides comprehensive codebase context for agents
+    # require-repomix-artifact: true
 
     # Optionally require specific jobs to be present
     # required-jobs:

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -228,20 +228,20 @@ func (l *Linter) addGitHubWorkflowsRule(rulesList *[]rules.Rule) {
 			requireSecurity := l.getBoolFromMap(configMap, "require-security")
 			requireQuality := l.getBoolFromMap(configMap, "require-quality")
 			requireLogCommits := l.getBoolFromMap(configMap, "require-log-commits")
-			requireLogArtifacts := l.getBoolFromMap(configMap, "require-log-artifacts")
+			requireRepomixArtifact := l.getBoolFromMap(configMap, "require-repomix-artifact")
 			requiredJobs := l.getStringSliceFromMap(configMap, "required-jobs")
 			requiredTriggers := l.getStringSliceFromMap(configMap, "required-triggers")
 			allowMissing := l.getStringSliceFromMap(configMap, "allow-missing")
 
 			rule := rules.NewGitHubWorkflowsRule(rules.GitHubWorkflowsRule{
-				RequireTests:        requireTests,
-				RequireSecurity:     requireSecurity,
-				RequireQuality:      requireQuality,
-				RequireLogCommits:   requireLogCommits,
-				RequireLogArtifacts: requireLogArtifacts,
-				RequiredJobs:        requiredJobs,
-				RequiredTriggers:    requiredTriggers,
-				AllowMissing:        allowMissing,
+				RequireTests:          requireTests,
+				RequireSecurity:       requireSecurity,
+				RequireQuality:        requireQuality,
+				RequireLogCommits:     requireLogCommits,
+				RequireRepomixArtifact: requireRepomixArtifact,
+				RequiredJobs:          requiredJobs,
+				RequiredTriggers:      requiredTriggers,
+				AllowMissing:          allowMissing,
 			})
 			*rulesList = append(*rulesList, rule)
 		}


### PR DESCRIPTION
This commit adds two new configuration options to the github-workflows rule:
- require-log-commits: Enforces that workflows commit execution logs back to the triggering branch
- require-log-artifacts: Enforces that workflows upload logs as GitHub artifacts

These features enable automated agents (like Claude) to pull branches and review workflow execution results directly, making it easier to debug CI/CD failures.

Changes:
- Extended GitHubWorkflowsRule struct with RequireLogCommits and RequireLogArtifacts fields
- Added WorkflowStep.If and WorkflowStep.With fields to parse conditional steps and action parameters
- Implemented hasLogCommitSteps() to validate presence of log creation, git commit, and git push
- Implemented hasLogArtifactSteps() to validate upload-artifact actions with log paths
- Added comprehensive tests for both logging requirements (4 new test cases)
- Registered rule in linter with proper configuration extraction
- Updated documentation with detailed examples and best practices
- Updated example configuration files

The rule validates:
1. Log file creation using 'tee' or '>' redirection to .log files
2. Git commit steps (git add, git commit) for log commits
3. Git push steps to publish logs to the branch
4. Upload-artifact actions with log file paths for artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `require-log-commits` optional rule for GitHub workflows to enforce execution log commits back to the triggering branch.
  * Added `require-repomix-artifact` optional rule for GitHub workflows to enforce codebase packaging and artifact uploads.

* **Documentation**
  * Updated documentation with detailed violation and valid examples for both new GitHub workflow rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->