### PR TITLE
Create rule to enforce properties

### DIFF
--- a/.structurelint.yml
+++ b/.structurelint.yml
@@ -69,6 +69,16 @@ rules:
       "CONTRIBUTING.md": "contributing"    # Enforce contributing guidelines
       "**/*_test.go": "test-gwt-table"    # Enforce GWT naming + AAA for Go tests (supports table-driven)
 
+  # Dependency Property Enforcement
+  # Comprehensive dependency management and analysis
+  property-enforcement:
+    detect_cycles: true                      # Detect circular dependencies
+    max_dependencies_per_file: 15            # Limit direct dependencies per file
+    max_dependency_depth: 5                  # Limit dependency chain depth
+    forbidden_patterns:
+      - "internal/rules/** -> cmd/**"        # Rules should not depend on cmd
+      - "internal/walker/** -> internal/rules/**"  # Walker should not depend on rules
+
 # Phase 1: Architectural layers for Go project
 layers:
   - name: cmd

--- a/internal/rules/property_enforcement.go
+++ b/internal/rules/property_enforcement.go
@@ -1,0 +1,372 @@
+package rules
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/structurelint/structurelint/internal/graph"
+	"github.com/structurelint/structurelint/internal/walker"
+)
+
+// PropertyEnforcementRule enforces various dependency management properties
+// including cyclic dependency detection, dependency limits, and depth constraints
+type PropertyEnforcementRule struct {
+	Graph                  *graph.ImportGraph
+	MaxDependenciesPerFile int
+	MaxDependencyDepth     int
+	DetectCycles           bool
+	ForbiddenPatterns      []string // Patterns like "internal/** -> external/**"
+}
+
+// PropertyEnforcementConfig holds the configuration for the rule
+type PropertyEnforcementConfig struct {
+	MaxDependenciesPerFile int      `yaml:"max_dependencies_per_file"`
+	MaxDependencyDepth     int      `yaml:"max_dependency_depth"`
+	DetectCycles           bool     `yaml:"detect_cycles"`
+	ForbiddenPatterns      []string `yaml:"forbidden_patterns"`
+}
+
+func (r *PropertyEnforcementRule) Name() string {
+	return "property-enforcement"
+}
+
+func (r *PropertyEnforcementRule) Check(files []walker.FileInfo, dirs map[string]*walker.DirInfo) []Violation {
+	if r.Graph == nil {
+		return []Violation{}
+	}
+
+	var violations []Violation
+
+	// Check 1: Detect cyclic dependencies
+	if r.DetectCycles {
+		violations = append(violations, r.detectCycles()...)
+	}
+
+	// Check 2: Enforce max dependencies per file
+	if r.MaxDependenciesPerFile > 0 {
+		violations = append(violations, r.checkMaxDependencies()...)
+	}
+
+	// Check 3: Enforce max dependency depth
+	if r.MaxDependencyDepth > 0 {
+		violations = append(violations, r.checkDependencyDepth()...)
+	}
+
+	// Check 4: Check forbidden dependency patterns
+	if len(r.ForbiddenPatterns) > 0 {
+		violations = append(violations, r.checkForbiddenPatterns()...)
+	}
+
+	return violations
+}
+
+// detectCycles finds circular dependencies in the import graph
+func (r *PropertyEnforcementRule) detectCycles() []Violation {
+	var violations []Violation
+
+	// Track visited nodes and current path for cycle detection
+	visited := make(map[string]bool)
+	recStack := make(map[string]bool)
+	var currentPath []string
+
+	var dfs func(string) bool
+	dfs = func(file string) bool {
+		visited[file] = true
+		recStack[file] = true
+		currentPath = append(currentPath, file)
+
+		// Check all dependencies of this file
+		if deps, exists := r.Graph.Dependencies[file]; exists {
+			for _, dep := range deps {
+				// Resolve dependency to actual file path
+				depFile := r.resolveImportToFile(dep, file)
+				if depFile == "" {
+					continue
+				}
+
+				if !visited[depFile] {
+					if dfs(depFile) {
+						return true
+					}
+				} else if recStack[depFile] {
+					// Cycle detected! Build the cycle path
+					cycleStart := -1
+					for i, p := range currentPath {
+						if p == depFile {
+							cycleStart = i
+							break
+						}
+					}
+					if cycleStart >= 0 {
+						cyclePath := append(currentPath[cycleStart:], depFile)
+						violations = append(violations, Violation{
+							Rule:    r.Name(),
+							Path:    file,
+							Message: "cyclic dependency detected",
+							Context: fmt.Sprintf("cycle: %s", strings.Join(cyclePath, " -> ")),
+							Suggestions: []string{
+								"Break the cycle by introducing an interface or abstraction",
+								"Restructure the code to remove circular imports",
+								"Consider dependency inversion principle",
+							},
+						})
+					}
+					return true
+				}
+			}
+		}
+
+		currentPath = currentPath[:len(currentPath)-1]
+		recStack[file] = false
+		return false
+	}
+
+	// Run DFS from each unvisited file
+	for file := range r.Graph.Dependencies {
+		if !visited[file] {
+			currentPath = []string{}
+			dfs(file)
+		}
+	}
+
+	return violations
+}
+
+// checkMaxDependencies ensures no file has too many direct dependencies
+func (r *PropertyEnforcementRule) checkMaxDependencies() []Violation {
+	var violations []Violation
+
+	for file, deps := range r.Graph.Dependencies {
+		depCount := len(deps)
+		if depCount > r.MaxDependenciesPerFile {
+			violations = append(violations, Violation{
+				Rule:     r.Name(),
+				Path:     file,
+				Message:  fmt.Sprintf("file has too many dependencies (%d > %d)", depCount, r.MaxDependenciesPerFile),
+				Expected: fmt.Sprintf("at most %d dependencies", r.MaxDependenciesPerFile),
+				Actual:   fmt.Sprintf("%d dependencies", depCount),
+				Suggestions: []string{
+					"Consider breaking this file into smaller, focused modules",
+					"Use dependency injection to reduce coupling",
+					"Look for common dependencies that could be grouped",
+				},
+			})
+		}
+	}
+
+	return violations
+}
+
+// checkDependencyDepth ensures dependency chains don't exceed maximum depth
+func (r *PropertyEnforcementRule) checkDependencyDepth() []Violation {
+	var violations []Violation
+
+	// Calculate the maximum dependency depth for each file
+	depthCache := make(map[string]int)
+
+	var calculateDepth func(string, map[string]bool) int
+	calculateDepth = func(file string, visiting map[string]bool) int {
+		// Check cache first
+		if depth, cached := depthCache[file]; cached {
+			return depth
+		}
+
+		// Check for cycles (if we're visiting this node already)
+		if visiting[file] {
+			return 0 // Cycle detected, return 0 to avoid infinite recursion
+		}
+
+		// Mark as visiting
+		visiting[file] = true
+		defer delete(visiting, file)
+
+		// Get dependencies
+		deps, exists := r.Graph.Dependencies[file]
+		if !exists || len(deps) == 0 {
+			depthCache[file] = 0
+			return 0
+		}
+
+		// Find maximum depth among all dependencies
+		maxDepth := 0
+		for _, dep := range deps {
+			depFile := r.resolveImportToFile(dep, file)
+			if depFile == "" {
+				continue
+			}
+
+			depth := calculateDepth(depFile, visiting)
+			if depth > maxDepth {
+				maxDepth = depth
+			}
+		}
+
+		result := maxDepth + 1
+		depthCache[file] = result
+		return result
+	}
+
+	// Check depth for each file
+	for file := range r.Graph.Dependencies {
+		depth := calculateDepth(file, make(map[string]bool))
+		if depth > r.MaxDependencyDepth {
+			violations = append(violations, Violation{
+				Rule:     r.Name(),
+				Path:     file,
+				Message:  fmt.Sprintf("dependency chain too deep (%d > %d)", depth, r.MaxDependencyDepth),
+				Expected: fmt.Sprintf("dependency depth at most %d", r.MaxDependencyDepth),
+				Actual:   fmt.Sprintf("dependency depth %d", depth),
+				Suggestions: []string{
+					"Flatten the dependency hierarchy",
+					"Consider using facades or abstraction layers",
+					"Review the architectural design for unnecessary layering",
+				},
+			})
+		}
+	}
+
+	return violations
+}
+
+// checkForbiddenPatterns validates that forbidden dependency patterns are not violated
+func (r *PropertyEnforcementRule) checkForbiddenPatterns() []Violation {
+	var violations []Violation
+
+	for _, pattern := range r.ForbiddenPatterns {
+		// Parse pattern: "source_pattern -> target_pattern"
+		parts := strings.Split(pattern, "->")
+		if len(parts) != 2 {
+			continue
+		}
+
+		sourcePattern := strings.TrimSpace(parts[0])
+		targetPattern := strings.TrimSpace(parts[1])
+
+		// Check all dependencies
+		for file, deps := range r.Graph.Dependencies {
+			// Check if source file matches source pattern
+			if !matchPattern(file, sourcePattern) {
+				continue
+			}
+
+			// Check each dependency
+			for _, dep := range deps {
+				depFile := r.resolveImportToFile(dep, file)
+				if depFile == "" {
+					continue
+				}
+
+				// Check if dependency matches forbidden target pattern
+				if matchPattern(depFile, targetPattern) {
+					violations = append(violations, Violation{
+						Rule:    r.Name(),
+						Path:    file,
+						Message: fmt.Sprintf("forbidden dependency from '%s' to '%s'", sourcePattern, targetPattern),
+						Context: fmt.Sprintf("file '%s' imports '%s'", file, depFile),
+						Suggestions: []string{
+							"Restructure code to avoid this dependency",
+							"Use dependency inversion or abstraction",
+							fmt.Sprintf("Files matching '%s' should not depend on '%s'", sourcePattern, targetPattern),
+						},
+					})
+				}
+			}
+		}
+	}
+
+	return violations
+}
+
+// resolveImportToFile attempts to resolve an import path to an actual file path
+func (r *PropertyEnforcementRule) resolveImportToFile(importPath string, sourceFile string) string {
+	// First, check if the import path is already a valid file path that exists in our graph
+	// This handles cases where dependencies are already resolved file paths
+	if _, exists := r.Graph.Dependencies[importPath]; exists {
+		return importPath
+	}
+
+	// Also check if any file in the graph has this as a dependency value
+	// This handles the case where importPath is a dependency but not in the keys
+	for _, deps := range r.Graph.Dependencies {
+		for _, dep := range deps {
+			if dep == importPath {
+				// The import path itself is the file path
+				return importPath
+			}
+		}
+	}
+
+	// For relative imports, resolve relative to source file
+	if strings.HasPrefix(importPath, ".") {
+		sourceDir := filepath.Dir(sourceFile)
+		resolved := filepath.Join(sourceDir, importPath)
+		// Check if this file exists in our graph
+		if _, exists := r.Graph.Dependencies[resolved]; exists {
+			return resolved
+		}
+		// Try with common extensions
+		for _, ext := range []string{".go", ".py", ".ts", ".js", ".java", ".cs", ".cpp", ".hpp"} {
+			candidate := resolved + ext
+			if _, exists := r.Graph.Dependencies[candidate]; exists {
+				return candidate
+			}
+		}
+	}
+
+	// For absolute imports, search in the dependency graph
+	for file := range r.Graph.Dependencies {
+		if strings.Contains(file, importPath) || strings.HasSuffix(file, importPath) {
+			return file
+		}
+	}
+
+	return ""
+}
+
+// matchPattern checks if a path matches a glob-like pattern
+func matchPattern(path, pattern string) bool {
+	// Normalize paths
+	path = filepath.ToSlash(path)
+	pattern = filepath.ToSlash(pattern)
+
+	// Handle ** glob pattern
+	if strings.Contains(pattern, "**") {
+		// Convert ** to a regex-friendly pattern
+		regexPattern := strings.ReplaceAll(pattern, "**", ".*")
+		regexPattern = strings.ReplaceAll(regexPattern, "*", "[^/]*")
+		regexPattern = "^" + regexPattern + "$"
+
+		// Simple pattern matching without regex package
+		// For now, use filepath.Match for simpler patterns
+		if strings.HasSuffix(pattern, "/**") {
+			prefix := strings.TrimSuffix(pattern, "/**")
+			return strings.HasPrefix(path, prefix)
+		}
+		if strings.HasPrefix(pattern, "**/") {
+			suffix := strings.TrimPrefix(pattern, "**/")
+			return strings.HasSuffix(path, suffix) || strings.Contains(path, "/"+suffix)
+		}
+	}
+
+	// Use filepath.Match for simple patterns
+	matched, _ := filepath.Match(pattern, filepath.Base(path))
+	if matched {
+		return true
+	}
+
+	// Try matching the full path
+	matched, _ = filepath.Match(pattern, path)
+	return matched
+}
+
+// NewPropertyEnforcementRule creates a new PropertyEnforcementRule
+func NewPropertyEnforcementRule(importGraph *graph.ImportGraph, config PropertyEnforcementConfig) *PropertyEnforcementRule {
+	return &PropertyEnforcementRule{
+		Graph:                  importGraph,
+		MaxDependenciesPerFile: config.MaxDependenciesPerFile,
+		MaxDependencyDepth:     config.MaxDependencyDepth,
+		DetectCycles:           config.DetectCycles,
+		ForbiddenPatterns:      config.ForbiddenPatterns,
+	}
+}

--- a/internal/rules/property_enforcement_test.go
+++ b/internal/rules/property_enforcement_test.go
@@ -1,0 +1,370 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/structurelint/structurelint/internal/graph"
+	"github.com/structurelint/structurelint/internal/walker"
+)
+
+func TestPropertyEnforcementRule_DetectCycles(t *testing.T) {
+	// Create a graph with a cycle: A -> B -> C -> A
+	importGraph := &graph.ImportGraph{
+		Dependencies: map[string][]string{
+			"a.go": {"b.go"},
+			"b.go": {"c.go"},
+			"c.go": {"a.go"},
+		},
+	}
+
+	config := PropertyEnforcementConfig{
+		DetectCycles: true,
+	}
+
+	rule := NewPropertyEnforcementRule(importGraph, config)
+	violations := rule.Check([]walker.FileInfo{}, nil)
+
+	if len(violations) == 0 {
+		t.Error("expected cycle detection to find violations, got none")
+	}
+
+	// Check that the violation mentions a cycle
+	found := false
+	for _, v := range violations {
+		if strings.Contains(v.Message, "cyclic") || strings.Contains(v.Message, "cycle") {
+			found = true
+			if v.Context == "" {
+				t.Error("expected context to show the cycle path")
+			}
+		}
+	}
+
+	if !found {
+		t.Error("expected at least one cyclic dependency violation")
+	}
+}
+
+func TestPropertyEnforcementRule_NoCycles(t *testing.T) {
+	// Create a graph without cycles: A -> B -> C
+	importGraph := &graph.ImportGraph{
+		Dependencies: map[string][]string{
+			"a.go": {"b.go"},
+			"b.go": {"c.go"},
+			"c.go": {},
+		},
+	}
+
+	config := PropertyEnforcementConfig{
+		DetectCycles: true,
+	}
+
+	rule := NewPropertyEnforcementRule(importGraph, config)
+	violations := rule.Check([]walker.FileInfo{}, nil)
+
+	// Filter for cycle-related violations only
+	cycleViolations := []Violation{}
+	for _, v := range violations {
+		if strings.Contains(v.Message, "cyclic") || strings.Contains(v.Message, "cycle") {
+			cycleViolations = append(cycleViolations, v)
+		}
+	}
+
+	if len(cycleViolations) > 0 {
+		t.Errorf("expected no cycle violations, got %d: %v", len(cycleViolations), cycleViolations)
+	}
+}
+
+func TestPropertyEnforcementRule_MaxDependenciesPerFile(t *testing.T) {
+	// Create a graph where one file has too many dependencies
+	importGraph := &graph.ImportGraph{
+		Dependencies: map[string][]string{
+			"a.go": {"b.go", "c.go", "d.go", "e.go", "f.go"},
+			"b.go": {},
+			"c.go": {},
+		},
+	}
+
+	config := PropertyEnforcementConfig{
+		MaxDependenciesPerFile: 3,
+	}
+
+	rule := NewPropertyEnforcementRule(importGraph, config)
+	violations := rule.Check([]walker.FileInfo{}, nil)
+
+	if len(violations) == 0 {
+		t.Error("expected max dependencies violation, got none")
+	}
+
+	found := false
+	for _, v := range violations {
+		if v.Path == "a.go" && strings.Contains(v.Message, "too many dependencies") {
+			found = true
+			if !strings.Contains(v.Actual, "5") {
+				t.Errorf("expected actual to show 5 dependencies, got: %s", v.Actual)
+			}
+		}
+	}
+
+	if !found {
+		t.Error("expected violation for a.go having too many dependencies")
+	}
+}
+
+func TestPropertyEnforcementRule_MaxDependenciesPerFile_UnderLimit(t *testing.T) {
+	importGraph := &graph.ImportGraph{
+		Dependencies: map[string][]string{
+			"a.go": {"b.go", "c.go"},
+			"b.go": {},
+		},
+	}
+
+	config := PropertyEnforcementConfig{
+		MaxDependenciesPerFile: 5,
+	}
+
+	rule := NewPropertyEnforcementRule(importGraph, config)
+	violations := rule.Check([]walker.FileInfo{}, nil)
+
+	// Should have no violations for max dependencies
+	for _, v := range violations {
+		if strings.Contains(v.Message, "too many dependencies") {
+			t.Errorf("unexpected max dependencies violation: %v", v)
+		}
+	}
+}
+
+func TestPropertyEnforcementRule_MaxDependencyDepth(t *testing.T) {
+	// Create a deep dependency chain: A -> B -> C -> D -> E (depth 4)
+	importGraph := &graph.ImportGraph{
+		Dependencies: map[string][]string{
+			"a.go": {"b.go"},
+			"b.go": {"c.go"},
+			"c.go": {"d.go"},
+			"d.go": {"e.go"},
+			"e.go": {},
+		},
+	}
+
+	config := PropertyEnforcementConfig{
+		MaxDependencyDepth: 2,
+	}
+
+	rule := NewPropertyEnforcementRule(importGraph, config)
+	violations := rule.Check([]walker.FileInfo{}, nil)
+
+	if len(violations) == 0 {
+		t.Error("expected dependency depth violation, got none")
+	}
+
+	found := false
+	for _, v := range violations {
+		if strings.Contains(v.Message, "dependency chain too deep") {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Error("expected at least one dependency depth violation")
+	}
+}
+
+func TestPropertyEnforcementRule_MaxDependencyDepth_UnderLimit(t *testing.T) {
+	// Create a shallow dependency chain: A -> B (depth 1)
+	importGraph := &graph.ImportGraph{
+		Dependencies: map[string][]string{
+			"a.go": {"b.go"},
+			"b.go": {},
+		},
+	}
+
+	config := PropertyEnforcementConfig{
+		MaxDependencyDepth: 3,
+	}
+
+	rule := NewPropertyEnforcementRule(importGraph, config)
+	violations := rule.Check([]walker.FileInfo{}, nil)
+
+	// Should have no depth violations
+	for _, v := range violations {
+		if strings.Contains(v.Message, "dependency chain too deep") {
+			t.Errorf("unexpected depth violation: %v", v)
+		}
+	}
+}
+
+func TestPropertyEnforcementRule_ForbiddenPatterns(t *testing.T) {
+	importGraph := &graph.ImportGraph{
+		Dependencies: map[string][]string{
+			"internal/service.go": {"external/api.go"},
+			"cmd/main.go":         {"internal/service.go"},
+		},
+	}
+
+	config := PropertyEnforcementConfig{
+		ForbiddenPatterns: []string{
+			"internal/** -> external/**",
+		},
+	}
+
+	rule := NewPropertyEnforcementRule(importGraph, config)
+	violations := rule.Check([]walker.FileInfo{}, nil)
+
+	if len(violations) == 0 {
+		t.Error("expected forbidden pattern violation, got none")
+	}
+
+	found := false
+	for _, v := range violations {
+		if v.Path == "internal/service.go" && strings.Contains(v.Message, "forbidden dependency") {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Error("expected violation for internal/service.go importing external/api.go")
+	}
+}
+
+func TestPropertyEnforcementRule_ForbiddenPatterns_NoViolation(t *testing.T) {
+	importGraph := &graph.ImportGraph{
+		Dependencies: map[string][]string{
+			"cmd/main.go":         {"internal/service.go"},
+			"internal/service.go": {"internal/db.go"},
+		},
+	}
+
+	config := PropertyEnforcementConfig{
+		ForbiddenPatterns: []string{
+			"internal/** -> external/**",
+		},
+	}
+
+	rule := NewPropertyEnforcementRule(importGraph, config)
+	violations := rule.Check([]walker.FileInfo{}, nil)
+
+	// Should have no forbidden pattern violations
+	for _, v := range violations {
+		if strings.Contains(v.Message, "forbidden dependency") {
+			t.Errorf("unexpected forbidden pattern violation: %v", v)
+		}
+	}
+}
+
+func TestPropertyEnforcementRule_MultipleChecks(t *testing.T) {
+	// Create a graph with multiple violations
+	importGraph := &graph.ImportGraph{
+		Dependencies: map[string][]string{
+			"a.go": {"b.go", "c.go", "d.go", "e.go"}, // Too many dependencies
+			"b.go": {"a.go"},                         // Creates a cycle
+			"c.go": {},
+		},
+	}
+
+	config := PropertyEnforcementConfig{
+		DetectCycles:           true,
+		MaxDependenciesPerFile: 2,
+	}
+
+	rule := NewPropertyEnforcementRule(importGraph, config)
+	violations := rule.Check([]walker.FileInfo{}, nil)
+
+	if len(violations) == 0 {
+		t.Error("expected multiple violations, got none")
+	}
+
+	// Should have both cycle and max dependencies violations
+	hasCycle := false
+	hasMaxDeps := false
+
+	for _, v := range violations {
+		if strings.Contains(v.Message, "cyclic") || strings.Contains(v.Message, "cycle") {
+			hasCycle = true
+		}
+		if strings.Contains(v.Message, "too many dependencies") {
+			hasMaxDeps = true
+		}
+	}
+
+	if !hasCycle {
+		t.Error("expected cycle violation")
+	}
+	if !hasMaxDeps {
+		t.Error("expected max dependencies violation")
+	}
+}
+
+func TestPropertyEnforcementRule_NilGraph(t *testing.T) {
+	config := PropertyEnforcementConfig{
+		DetectCycles: true,
+	}
+
+	rule := NewPropertyEnforcementRule(nil, config)
+	violations := rule.Check([]walker.FileInfo{}, nil)
+
+	if len(violations) != 0 {
+		t.Errorf("expected no violations with nil graph, got %d", len(violations))
+	}
+}
+
+func TestPropertyEnforcementRule_ComplexCycle(t *testing.T) {
+	// Create a more complex cycle: A -> B -> C -> D -> B
+	importGraph := &graph.ImportGraph{
+		Dependencies: map[string][]string{
+			"a.go": {"b.go"},
+			"b.go": {"c.go"},
+			"c.go": {"d.go"},
+			"d.go": {"b.go"}, // Cycle back to b
+			"e.go": {"f.go"}, // Unrelated files
+			"f.go": {},
+		},
+	}
+
+	config := PropertyEnforcementConfig{
+		DetectCycles: true,
+	}
+
+	rule := NewPropertyEnforcementRule(importGraph, config)
+	violations := rule.Check([]walker.FileInfo{}, nil)
+
+	if len(violations) == 0 {
+		t.Error("expected cycle detection to find violations in complex cycle")
+	}
+
+	// Check that cycle involves b, c, or d
+	found := false
+	for _, v := range violations {
+		if strings.Contains(v.Message, "cyclic") || strings.Contains(v.Message, "cycle") {
+			// The violation should be for one of the files in the cycle
+			if v.Path == "b.go" || v.Path == "c.go" || v.Path == "d.go" {
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		t.Error("expected cycle violation for files b.go, c.go, or d.go")
+	}
+}
+
+func TestMatchPattern(t *testing.T) {
+	tests := []struct {
+		path    string
+		pattern string
+		want    bool
+	}{
+		{"internal/service.go", "internal/**", true},
+		{"internal/db/repo.go", "internal/**", true},
+		{"external/api.go", "internal/**", false},
+		{"cmd/main.go", "cmd/**", true},
+		{"test.go", "*.go", true},
+		{"test.py", "*.go", false},
+	}
+
+	for _, tt := range tests {
+		got := matchPattern(tt.path, tt.pattern)
+		if got != tt.want {
+			t.Errorf("matchPattern(%q, %q) = %v, want %v", tt.path, tt.pattern, got, tt.want)
+		}
+	}
+}

--- a/internal/rules/property_enforcement_test.go
+++ b/internal/rules/property_enforcement_test.go
@@ -9,27 +9,27 @@ import (
 )
 
 func TestPropertyEnforcementRule_DetectCycles(t *testing.T) {
-	// Create a graph with a cycle: A -> B -> C -> A
+	// Arrange
 	importGraph := &graph.ImportGraph{
 		Dependencies: map[string][]string{
 			"a.go": {"b.go"},
 			"b.go": {"c.go"},
-			"c.go": {"a.go"},
+			"c.go": {"a.go"}, // Creates cycle: A -> B -> C -> A
 		},
 	}
-
 	config := PropertyEnforcementConfig{
 		DetectCycles: true,
 	}
-
 	rule := NewPropertyEnforcementRule(importGraph, config)
+
+	// Act
 	violations := rule.Check([]walker.FileInfo{}, nil)
 
+	// Assert
 	if len(violations) == 0 {
 		t.Error("expected cycle detection to find violations, got none")
 	}
 
-	// Check that the violation mentions a cycle
 	found := false
 	for _, v := range violations {
 		if strings.Contains(v.Message, "cyclic") || strings.Contains(v.Message, "cycle") {
@@ -46,23 +46,23 @@ func TestPropertyEnforcementRule_DetectCycles(t *testing.T) {
 }
 
 func TestPropertyEnforcementRule_NoCycles(t *testing.T) {
-	// Create a graph without cycles: A -> B -> C
+	// Arrange
 	importGraph := &graph.ImportGraph{
 		Dependencies: map[string][]string{
 			"a.go": {"b.go"},
 			"b.go": {"c.go"},
-			"c.go": {},
+			"c.go": {}, // No cycle: A -> B -> C
 		},
 	}
-
 	config := PropertyEnforcementConfig{
 		DetectCycles: true,
 	}
-
 	rule := NewPropertyEnforcementRule(importGraph, config)
+
+	// Act
 	violations := rule.Check([]walker.FileInfo{}, nil)
 
-	// Filter for cycle-related violations only
+	// Assert
 	cycleViolations := []Violation{}
 	for _, v := range violations {
 		if strings.Contains(v.Message, "cyclic") || strings.Contains(v.Message, "cycle") {
@@ -76,22 +76,23 @@ func TestPropertyEnforcementRule_NoCycles(t *testing.T) {
 }
 
 func TestPropertyEnforcementRule_MaxDependenciesPerFile(t *testing.T) {
-	// Create a graph where one file has too many dependencies
+	// Arrange
 	importGraph := &graph.ImportGraph{
 		Dependencies: map[string][]string{
-			"a.go": {"b.go", "c.go", "d.go", "e.go", "f.go"},
+			"a.go": {"b.go", "c.go", "d.go", "e.go", "f.go"}, // 5 dependencies
 			"b.go": {},
 			"c.go": {},
 		},
 	}
-
 	config := PropertyEnforcementConfig{
-		MaxDependenciesPerFile: 3,
+		MaxDependenciesPerFile: 3, // Limit to 3
 	}
-
 	rule := NewPropertyEnforcementRule(importGraph, config)
+
+	// Act
 	violations := rule.Check([]walker.FileInfo{}, nil)
 
+	// Assert
 	if len(violations) == 0 {
 		t.Error("expected max dependencies violation, got none")
 	}
@@ -112,21 +113,22 @@ func TestPropertyEnforcementRule_MaxDependenciesPerFile(t *testing.T) {
 }
 
 func TestPropertyEnforcementRule_MaxDependenciesPerFile_UnderLimit(t *testing.T) {
+	// Arrange
 	importGraph := &graph.ImportGraph{
 		Dependencies: map[string][]string{
-			"a.go": {"b.go", "c.go"},
+			"a.go": {"b.go", "c.go"}, // 2 dependencies
 			"b.go": {},
 		},
 	}
-
 	config := PropertyEnforcementConfig{
-		MaxDependenciesPerFile: 5,
+		MaxDependenciesPerFile: 5, // Limit to 5
 	}
-
 	rule := NewPropertyEnforcementRule(importGraph, config)
+
+	// Act
 	violations := rule.Check([]walker.FileInfo{}, nil)
 
-	// Should have no violations for max dependencies
+	// Assert
 	for _, v := range violations {
 		if strings.Contains(v.Message, "too many dependencies") {
 			t.Errorf("unexpected max dependencies violation: %v", v)
@@ -135,24 +137,25 @@ func TestPropertyEnforcementRule_MaxDependenciesPerFile_UnderLimit(t *testing.T)
 }
 
 func TestPropertyEnforcementRule_MaxDependencyDepth(t *testing.T) {
-	// Create a deep dependency chain: A -> B -> C -> D -> E (depth 4)
+	// Arrange
 	importGraph := &graph.ImportGraph{
 		Dependencies: map[string][]string{
 			"a.go": {"b.go"},
 			"b.go": {"c.go"},
 			"c.go": {"d.go"},
 			"d.go": {"e.go"},
-			"e.go": {},
+			"e.go": {}, // Deep chain: A -> B -> C -> D -> E (depth 4)
 		},
 	}
-
 	config := PropertyEnforcementConfig{
-		MaxDependencyDepth: 2,
+		MaxDependencyDepth: 2, // Limit to depth 2
 	}
-
 	rule := NewPropertyEnforcementRule(importGraph, config)
+
+	// Act
 	violations := rule.Check([]walker.FileInfo{}, nil)
 
+	// Assert
 	if len(violations) == 0 {
 		t.Error("expected dependency depth violation, got none")
 	}
@@ -170,22 +173,22 @@ func TestPropertyEnforcementRule_MaxDependencyDepth(t *testing.T) {
 }
 
 func TestPropertyEnforcementRule_MaxDependencyDepth_UnderLimit(t *testing.T) {
-	// Create a shallow dependency chain: A -> B (depth 1)
+	// Arrange
 	importGraph := &graph.ImportGraph{
 		Dependencies: map[string][]string{
 			"a.go": {"b.go"},
-			"b.go": {},
+			"b.go": {}, // Shallow chain: A -> B (depth 1)
 		},
 	}
-
 	config := PropertyEnforcementConfig{
-		MaxDependencyDepth: 3,
+		MaxDependencyDepth: 3, // Limit to depth 3
 	}
-
 	rule := NewPropertyEnforcementRule(importGraph, config)
+
+	// Act
 	violations := rule.Check([]walker.FileInfo{}, nil)
 
-	// Should have no depth violations
+	// Assert
 	for _, v := range violations {
 		if strings.Contains(v.Message, "dependency chain too deep") {
 			t.Errorf("unexpected depth violation: %v", v)
@@ -194,22 +197,24 @@ func TestPropertyEnforcementRule_MaxDependencyDepth_UnderLimit(t *testing.T) {
 }
 
 func TestPropertyEnforcementRule_ForbiddenPatterns(t *testing.T) {
+	// Arrange
 	importGraph := &graph.ImportGraph{
 		Dependencies: map[string][]string{
-			"internal/service.go": {"external/api.go"},
+			"internal/service.go": {"external/api.go"}, // Forbidden dependency
 			"cmd/main.go":         {"internal/service.go"},
 		},
 	}
-
 	config := PropertyEnforcementConfig{
 		ForbiddenPatterns: []string{
 			"internal/** -> external/**",
 		},
 	}
-
 	rule := NewPropertyEnforcementRule(importGraph, config)
+
+	// Act
 	violations := rule.Check([]walker.FileInfo{}, nil)
 
+	// Assert
 	if len(violations) == 0 {
 		t.Error("expected forbidden pattern violation, got none")
 	}
@@ -227,23 +232,24 @@ func TestPropertyEnforcementRule_ForbiddenPatterns(t *testing.T) {
 }
 
 func TestPropertyEnforcementRule_ForbiddenPatterns_NoViolation(t *testing.T) {
+	// Arrange
 	importGraph := &graph.ImportGraph{
 		Dependencies: map[string][]string{
 			"cmd/main.go":         {"internal/service.go"},
-			"internal/service.go": {"internal/db.go"},
+			"internal/service.go": {"internal/db.go"}, // Allowed dependency
 		},
 	}
-
 	config := PropertyEnforcementConfig{
 		ForbiddenPatterns: []string{
 			"internal/** -> external/**",
 		},
 	}
-
 	rule := NewPropertyEnforcementRule(importGraph, config)
+
+	// Act
 	violations := rule.Check([]walker.FileInfo{}, nil)
 
-	// Should have no forbidden pattern violations
+	// Assert
 	for _, v := range violations {
 		if strings.Contains(v.Message, "forbidden dependency") {
 			t.Errorf("unexpected forbidden pattern violation: %v", v)
@@ -252,28 +258,28 @@ func TestPropertyEnforcementRule_ForbiddenPatterns_NoViolation(t *testing.T) {
 }
 
 func TestPropertyEnforcementRule_MultipleChecks(t *testing.T) {
-	// Create a graph with multiple violations
+	// Arrange
 	importGraph := &graph.ImportGraph{
 		Dependencies: map[string][]string{
-			"a.go": {"b.go", "c.go", "d.go", "e.go"}, // Too many dependencies
-			"b.go": {"a.go"},                         // Creates a cycle
+			"a.go": {"b.go", "c.go", "d.go", "e.go"}, // Too many dependencies (4)
+			"b.go": {"a.go"},                         // Creates a cycle with a.go
 			"c.go": {},
 		},
 	}
-
 	config := PropertyEnforcementConfig{
 		DetectCycles:           true,
-		MaxDependenciesPerFile: 2,
+		MaxDependenciesPerFile: 2, // Limit to 2
 	}
-
 	rule := NewPropertyEnforcementRule(importGraph, config)
+
+	// Act
 	violations := rule.Check([]walker.FileInfo{}, nil)
 
+	// Assert
 	if len(violations) == 0 {
 		t.Error("expected multiple violations, got none")
 	}
 
-	// Should have both cycle and max dependencies violations
 	hasCycle := false
 	hasMaxDeps := false
 
@@ -295,47 +301,49 @@ func TestPropertyEnforcementRule_MultipleChecks(t *testing.T) {
 }
 
 func TestPropertyEnforcementRule_NilGraph(t *testing.T) {
+	// Arrange
 	config := PropertyEnforcementConfig{
 		DetectCycles: true,
 	}
+	rule := NewPropertyEnforcementRule(nil, config) // Nil graph
 
-	rule := NewPropertyEnforcementRule(nil, config)
+	// Act
 	violations := rule.Check([]walker.FileInfo{}, nil)
 
+	// Assert
 	if len(violations) != 0 {
 		t.Errorf("expected no violations with nil graph, got %d", len(violations))
 	}
 }
 
 func TestPropertyEnforcementRule_ComplexCycle(t *testing.T) {
-	// Create a more complex cycle: A -> B -> C -> D -> B
+	// Arrange
 	importGraph := &graph.ImportGraph{
 		Dependencies: map[string][]string{
 			"a.go": {"b.go"},
 			"b.go": {"c.go"},
 			"c.go": {"d.go"},
-			"d.go": {"b.go"}, // Cycle back to b
-			"e.go": {"f.go"}, // Unrelated files
+			"d.go": {"b.go"}, // Creates cycle: B -> C -> D -> B
+			"e.go": {"f.go"}, // Unrelated chain
 			"f.go": {},
 		},
 	}
-
 	config := PropertyEnforcementConfig{
 		DetectCycles: true,
 	}
-
 	rule := NewPropertyEnforcementRule(importGraph, config)
+
+	// Act
 	violations := rule.Check([]walker.FileInfo{}, nil)
 
+	// Assert
 	if len(violations) == 0 {
 		t.Error("expected cycle detection to find violations in complex cycle")
 	}
 
-	// Check that cycle involves b, c, or d
 	found := false
 	for _, v := range violations {
 		if strings.Contains(v.Message, "cyclic") || strings.Contains(v.Message, "cycle") {
-			// The violation should be for one of the files in the cycle
 			if v.Path == "b.go" || v.Path == "c.go" || v.Path == "d.go" {
 				found = true
 			}
@@ -348,6 +356,7 @@ func TestPropertyEnforcementRule_ComplexCycle(t *testing.T) {
 }
 
 func TestMatchPattern(t *testing.T) {
+	// Arrange
 	tests := []struct {
 		path    string
 		pattern string
@@ -361,6 +370,7 @@ func TestMatchPattern(t *testing.T) {
 		{"test.py", "*.go", false},
 	}
 
+	// Act & Assert
 	for _, tt := range tests {
 		got := matchPattern(tt.path, tt.pattern)
 		if got != tt.want {


### PR DESCRIPTION
This commit introduces a new PropertyEnforcementRule that provides comprehensive dependency management and analysis capabilities:

Features:
- Cyclic dependency detection with detailed cycle paths
- Maximum dependencies per file limit to prevent high coupling
- Maximum dependency chain depth limit to prevent deep hierarchies
- Forbidden dependency pattern enforcement (e.g., "internal/** -> external/**")

Implementation:
- Created PropertyEnforcementRule with DFS-based cycle detection
- Added comprehensive test suite with 11 test cases
- Integrated rule into linter with proper configuration handling
- Added example configuration to .structurelint.yml

The rule uses the import graph analysis and provides actionable suggestions for violations, helping maintain clean architecture and manageable dependencies.