### PR TITLE
Add linting rules for markdown, CSS, and HTML

### DIFF
--- a/internal/rules/linter_config.go
+++ b/internal/rules/linter_config.go
@@ -51,6 +51,12 @@ func (r *LinterConfigRule) Name() string {
 	return "linter-config"
 }
 
+// languageCheck represents a language to check for linter configuration
+type languageCheck struct {
+	enabled      bool
+	languageKey  string
+}
+
 // Check validates linter configuration requirements
 func (r *LinterConfigRule) Check(files []walker.FileInfo, dirs map[string]*walker.DirInfo) []Violation {
 	var violations []Violation
@@ -61,60 +67,27 @@ func (r *LinterConfigRule) Check(files []walker.FileInfo, dirs map[string]*walke
 	// Define linter configurations for each language
 	linterConfigs := r.getLinterConfigs()
 
-	// Check each language
-	if r.RequirePython && languages["python"] {
-		pythonViolations := r.checkLanguageLinters(files, linterConfigs["python"])
-		violations = append(violations, pythonViolations...)
+	// Define language checks to perform
+	languageChecks := []languageCheck{
+		{r.RequirePython, "python"},
+		{r.RequireTypeScript, "typescript"},
+		{r.RequireGo, "go"},
+		{r.RequireHTML, "html"},
+		{r.RequireCSS, "css"},
+		{r.RequireSQL, "sql"},
+		{r.RequireRust, "rust"},
+		{r.RequireMarkdown, "markdown"},
+		{r.RequireJava, "java"},
+		{r.RequireCpp, "cpp"},
+		{r.RequireCSharp, "csharp"},
 	}
 
-	if r.RequireTypeScript && languages["typescript"] {
-		tsViolations := r.checkLanguageLinters(files, linterConfigs["typescript"])
-		violations = append(violations, tsViolations...)
-	}
-
-	if r.RequireGo && languages["go"] {
-		goViolations := r.checkLanguageLinters(files, linterConfigs["go"])
-		violations = append(violations, goViolations...)
-	}
-
-	if r.RequireHTML && languages["html"] {
-		htmlViolations := r.checkLanguageLinters(files, linterConfigs["html"])
-		violations = append(violations, htmlViolations...)
-	}
-
-	if r.RequireCSS && languages["css"] {
-		cssViolations := r.checkLanguageLinters(files, linterConfigs["css"])
-		violations = append(violations, cssViolations...)
-	}
-
-	if r.RequireSQL && languages["sql"] {
-		sqlViolations := r.checkLanguageLinters(files, linterConfigs["sql"])
-		violations = append(violations, sqlViolations...)
-	}
-
-	if r.RequireRust && languages["rust"] {
-		rustViolations := r.checkLanguageLinters(files, linterConfigs["rust"])
-		violations = append(violations, rustViolations...)
-	}
-
-	if r.RequireMarkdown && languages["markdown"] {
-		markdownViolations := r.checkLanguageLinters(files, linterConfigs["markdown"])
-		violations = append(violations, markdownViolations...)
-	}
-
-	if r.RequireJava && languages["java"] {
-		javaViolations := r.checkLanguageLinters(files, linterConfigs["java"])
-		violations = append(violations, javaViolations...)
-	}
-
-	if r.RequireCpp && languages["cpp"] {
-		cppViolations := r.checkLanguageLinters(files, linterConfigs["cpp"])
-		violations = append(violations, cppViolations...)
-	}
-
-	if r.RequireCSharp && languages["csharp"] {
-		csharpViolations := r.checkLanguageLinters(files, linterConfigs["csharp"])
-		violations = append(violations, csharpViolations...)
+	// Check each enabled language
+	for _, check := range languageChecks {
+		if check.enabled && languages[check.languageKey] {
+			langViolations := r.checkLanguageLinters(files, linterConfigs[check.languageKey])
+			violations = append(violations, langViolations...)
+		}
 	}
 
 	return violations

--- a/internal/rules/linter_config_test.go
+++ b/internal/rules/linter_config_test.go
@@ -530,224 +530,142 @@ func TestLinterConfigRule_AllLanguages(t *testing.T) {
 	}
 }
 
-func TestLinterConfigRule_MarkdownWithConfig(t *testing.T) {
-	// Arrange
-	rule := &LinterConfigRule{
-		RequireMarkdown: true,
-	}
-	files := []walker.FileInfo{
-		{Path: "README.md", ParentPath: ".", IsDir: false},
-		{Path: ".markdownlint.json", ParentPath: ".", IsDir: false},
-	}
-
-	// Act
-	violations := rule.Check(files, make(map[string]*walker.DirInfo))
-
-	// Assert
-	if len(violations) != 0 {
-		t.Errorf("Expected no violations with .markdownlint.json, got %d violations", len(violations))
-	}
-}
-
-func TestLinterConfigRule_MarkdownWithoutConfig(t *testing.T) {
-	// Arrange
-	rule := &LinterConfigRule{
-		RequireMarkdown: true,
-	}
-	files := []walker.FileInfo{
-		{Path: "README.md", ParentPath: ".", IsDir: false},
-		{Path: "package.json", ParentPath: ".", IsDir: false},
-	}
-
-	// Act
-	violations := rule.Check(files, make(map[string]*walker.DirInfo))
-
-	// Assert
-	if len(violations) == 0 {
-		t.Error("Expected violation for missing Markdown linter configuration")
-	}
-	if !containsMessage(violations, "No Markdown linter configuration found") {
-		t.Error("Expected violation message about missing Markdown linter configuration")
-	}
-}
-
-func TestLinterConfigRule_JavaWithCheckstyleConfig(t *testing.T) {
-	// Arrange
-	rule := &LinterConfigRule{
-		RequireJava: true,
-	}
-	files := []walker.FileInfo{
-		{Path: "src/Main.java", ParentPath: ".", IsDir: false},
-		{Path: "checkstyle.xml", ParentPath: ".", IsDir: false},
-	}
-
-	// Act
-	violations := rule.Check(files, make(map[string]*walker.DirInfo))
-
-	// Assert
-	if len(violations) != 0 {
-		t.Errorf("Expected no violations with checkstyle.xml, got %d violations", len(violations))
-	}
-}
-
-func TestLinterConfigRule_JavaWithPomXml(t *testing.T) {
-	// Arrange
-	rule := &LinterConfigRule{
-		RequireJava: true,
-	}
-	files := []walker.FileInfo{
-		{Path: "src/Main.java", ParentPath: ".", IsDir: false},
-		{Path: "pom.xml", ParentPath: ".", IsDir: false},
-	}
-
-	// Act
-	violations := rule.Check(files, make(map[string]*walker.DirInfo))
-
-	// Assert
-	if len(violations) != 0 {
-		t.Errorf("Expected no violations with pom.xml, got %d violations", len(violations))
-	}
-}
-
-func TestLinterConfigRule_JavaWithoutConfig(t *testing.T) {
-	// Arrange
-	rule := &LinterConfigRule{
-		RequireJava: true,
-	}
-	files := []walker.FileInfo{
-		{Path: "src/Main.java", ParentPath: ".", IsDir: false},
-		{Path: "README.md", ParentPath: ".", IsDir: false},
-	}
-
-	// Act
-	violations := rule.Check(files, make(map[string]*walker.DirInfo))
-
-	// Assert
-	if len(violations) == 0 {
-		t.Error("Expected violation for missing Java linter configuration")
-	}
-	if !containsMessage(violations, "No Java linter configuration found") {
-		t.Error("Expected violation message about missing Java linter configuration")
-	}
-}
-
-func TestLinterConfigRule_CppWithClangFormatConfig(t *testing.T) {
-	// Arrange
-	rule := &LinterConfigRule{
-		RequireCpp: true,
-	}
-	files := []walker.FileInfo{
-		{Path: "src/main.cpp", ParentPath: ".", IsDir: false},
-		{Path: ".clang-format", ParentPath: ".", IsDir: false},
-	}
-
-	// Act
-	violations := rule.Check(files, make(map[string]*walker.DirInfo))
-
-	// Assert
-	if len(violations) != 0 {
-		t.Errorf("Expected no violations with .clang-format, got %d violations", len(violations))
-	}
-}
-
-func TestLinterConfigRule_CppWithClangTidyConfig(t *testing.T) {
-	// Arrange
-	rule := &LinterConfigRule{
-		RequireCpp: true,
-	}
-	files := []walker.FileInfo{
-		{Path: "src/main.cpp", ParentPath: ".", IsDir: false},
-		{Path: ".clang-tidy", ParentPath: ".", IsDir: false},
+func TestLinterConfigRule_LanguageConfigurations(t *testing.T) {
+	tests := []struct {
+		name              string
+		rule              *LinterConfigRule
+		files             []walker.FileInfo
+		expectViolation   bool
+		expectedMessage   string
+	}{
+		// Markdown tests
+		{
+			name: "Markdown with config",
+			rule: &LinterConfigRule{RequireMarkdown: true},
+			files: []walker.FileInfo{
+				{Path: "README.md", ParentPath: ".", IsDir: false},
+				{Path: ".markdownlint.json", ParentPath: ".", IsDir: false},
+			},
+			expectViolation: false,
+		},
+		{
+			name: "Markdown without config",
+			rule: &LinterConfigRule{RequireMarkdown: true},
+			files: []walker.FileInfo{
+				{Path: "README.md", ParentPath: ".", IsDir: false},
+				{Path: "package.json", ParentPath: ".", IsDir: false},
+			},
+			expectViolation: true,
+			expectedMessage: "No Markdown linter configuration found",
+		},
+		// Java tests
+		{
+			name: "Java with Checkstyle config",
+			rule: &LinterConfigRule{RequireJava: true},
+			files: []walker.FileInfo{
+				{Path: "src/Main.java", ParentPath: ".", IsDir: false},
+				{Path: "checkstyle.xml", ParentPath: ".", IsDir: false},
+			},
+			expectViolation: false,
+		},
+		{
+			name: "Java with pom.xml",
+			rule: &LinterConfigRule{RequireJava: true},
+			files: []walker.FileInfo{
+				{Path: "src/Main.java", ParentPath: ".", IsDir: false},
+				{Path: "pom.xml", ParentPath: ".", IsDir: false},
+			},
+			expectViolation: false,
+		},
+		{
+			name: "Java without config",
+			rule: &LinterConfigRule{RequireJava: true},
+			files: []walker.FileInfo{
+				{Path: "src/Main.java", ParentPath: ".", IsDir: false},
+				{Path: "README.md", ParentPath: ".", IsDir: false},
+			},
+			expectViolation: true,
+			expectedMessage: "No Java linter configuration found",
+		},
+		// C++ tests
+		{
+			name: "C++ with clang-format config",
+			rule: &LinterConfigRule{RequireCpp: true},
+			files: []walker.FileInfo{
+				{Path: "src/main.cpp", ParentPath: ".", IsDir: false},
+				{Path: ".clang-format", ParentPath: ".", IsDir: false},
+			},
+			expectViolation: false,
+		},
+		{
+			name: "C++ with clang-tidy config",
+			rule: &LinterConfigRule{RequireCpp: true},
+			files: []walker.FileInfo{
+				{Path: "src/main.cpp", ParentPath: ".", IsDir: false},
+				{Path: ".clang-tidy", ParentPath: ".", IsDir: false},
+			},
+			expectViolation: false,
+		},
+		{
+			name: "C++ without config",
+			rule: &LinterConfigRule{RequireCpp: true},
+			files: []walker.FileInfo{
+				{Path: "src/main.cpp", ParentPath: ".", IsDir: false},
+				{Path: "README.md", ParentPath: ".", IsDir: false},
+			},
+			expectViolation: true,
+			expectedMessage: "No C++ linter configuration found",
+		},
+		// C# tests
+		{
+			name: "C# with EditorConfig",
+			rule: &LinterConfigRule{RequireCSharp: true},
+			files: []walker.FileInfo{
+				{Path: "src/Program.cs", ParentPath: ".", IsDir: false},
+				{Path: ".editorconfig", ParentPath: ".", IsDir: false},
+			},
+			expectViolation: false,
+		},
+		{
+			name: "C# with StyleCop config",
+			rule: &LinterConfigRule{RequireCSharp: true},
+			files: []walker.FileInfo{
+				{Path: "src/Program.cs", ParentPath: ".", IsDir: false},
+				{Path: "stylecop.json", ParentPath: ".", IsDir: false},
+			},
+			expectViolation: false,
+		},
+		{
+			name: "C# without config",
+			rule: &LinterConfigRule{RequireCSharp: true},
+			files: []walker.FileInfo{
+				{Path: "src/Program.cs", ParentPath: ".", IsDir: false},
+				{Path: "README.md", ParentPath: ".", IsDir: false},
+			},
+			expectViolation: true,
+			expectedMessage: "No C# linter configuration found",
+		},
 	}
 
-	// Act
-	violations := rule.Check(files, make(map[string]*walker.DirInfo))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Act
+			violations := tt.rule.Check(tt.files, make(map[string]*walker.DirInfo))
 
-	// Assert
-	if len(violations) != 0 {
-		t.Errorf("Expected no violations with .clang-tidy, got %d violations", len(violations))
-	}
-}
-
-func TestLinterConfigRule_CppWithoutConfig(t *testing.T) {
-	// Arrange
-	rule := &LinterConfigRule{
-		RequireCpp: true,
-	}
-	files := []walker.FileInfo{
-		{Path: "src/main.cpp", ParentPath: ".", IsDir: false},
-		{Path: "README.md", ParentPath: ".", IsDir: false},
-	}
-
-	// Act
-	violations := rule.Check(files, make(map[string]*walker.DirInfo))
-
-	// Assert
-	if len(violations) == 0 {
-		t.Error("Expected violation for missing C++ linter configuration")
-	}
-	if !containsMessage(violations, "No C++ linter configuration found") {
-		t.Error("Expected violation message about missing C++ linter configuration")
-	}
-}
-
-func TestLinterConfigRule_CSharpWithEditorConfig(t *testing.T) {
-	// Arrange
-	rule := &LinterConfigRule{
-		RequireCSharp: true,
-	}
-	files := []walker.FileInfo{
-		{Path: "src/Program.cs", ParentPath: ".", IsDir: false},
-		{Path: ".editorconfig", ParentPath: ".", IsDir: false},
-	}
-
-	// Act
-	violations := rule.Check(files, make(map[string]*walker.DirInfo))
-
-	// Assert
-	if len(violations) != 0 {
-		t.Errorf("Expected no violations with .editorconfig, got %d violations", len(violations))
-	}
-}
-
-func TestLinterConfigRule_CSharpWithStyleCopConfig(t *testing.T) {
-	// Arrange
-	rule := &LinterConfigRule{
-		RequireCSharp: true,
-	}
-	files := []walker.FileInfo{
-		{Path: "src/Program.cs", ParentPath: ".", IsDir: false},
-		{Path: "stylecop.json", ParentPath: ".", IsDir: false},
-	}
-
-	// Act
-	violations := rule.Check(files, make(map[string]*walker.DirInfo))
-
-	// Assert
-	if len(violations) != 0 {
-		t.Errorf("Expected no violations with stylecop.json, got %d violations", len(violations))
-	}
-}
-
-func TestLinterConfigRule_CSharpWithoutConfig(t *testing.T) {
-	// Arrange
-	rule := &LinterConfigRule{
-		RequireCSharp: true,
-	}
-	files := []walker.FileInfo{
-		{Path: "src/Program.cs", ParentPath: ".", IsDir: false},
-		{Path: "README.md", ParentPath: ".", IsDir: false},
-	}
-
-	// Act
-	violations := rule.Check(files, make(map[string]*walker.DirInfo))
-
-	// Assert
-	if len(violations) == 0 {
-		t.Error("Expected violation for missing C# linter configuration")
-	}
-	if !containsMessage(violations, "No C# linter configuration found") {
-		t.Error("Expected violation message about missing C# linter configuration")
+			// Assert
+			if tt.expectViolation {
+				if len(violations) == 0 {
+					t.Errorf("Expected violation but got none")
+				}
+				if tt.expectedMessage != "" && !containsMessage(violations, tt.expectedMessage) {
+					t.Errorf("Expected message '%s' but got: %v", tt.expectedMessage, violations)
+				}
+			} else {
+				if len(violations) != 0 {
+					t.Errorf("Expected no violations, got %d: %v", len(violations), violations)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
… and C#

This commit extends the linter-config rule to support additional languages and improves existing configurations with auto-fix suggestions:

New language support:
- Markdown: markdownlint, markdownlint-cli2, remark-lint
- Java: Checkstyle, PMD, SpotBugs (Maven and Gradle)
- C++: clang-format, clang-tidy, cppcheck
- C#: EditorConfig, StyleCop, dotnet format

Enhancements:
- Added html-eslint to HTML linter configuration
- Implemented auto-fix suggestions with best practice configs for all languages
- Added Expected/Actual fields to violations for better error reporting
- Comprehensive test coverage for all new language configurations

All tests pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added linter support for Markdown, Java, C++, and C# languages.
  * Enhanced missing-linter error reporting with expected configurations, actual state, and auto-fix suggestions.
  * Expanded HTML linter configurations with additional tooling options.

* **Tests**
  * Added comprehensive test coverage for new language linters and multi-language scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->