### PR TITLE
chore: switch CI runners to self-hosted [ABANDONED]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -62,7 +62,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -88,7 +88,7 @@ jobs:
 
   complexity:
     name: Check Complexity
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -165,7 +165,7 @@ jobs:
 
   self-lint:
     name: Self-Lint (Dogfooding)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code

--- a/.github/workflows/repomix.yml
+++ b/.github/workflows/repomix.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   repomix:
     name: Generate Repomixed Codebase
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code

--- a/.github/workflows/structurelint.yml
+++ b/.github/workflows/structurelint.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   lint:
     name: Lint Architecture
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -55,7 +55,7 @@ jobs:
   # Optional: Auto-fix violations
   autofix:
     name: Auto-fix Violations
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: github.event_name == 'pull_request'
 
     steps:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint-self:
     name: Lint Structurelint Project
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -39,7 +39,7 @@ jobs:
 
   test-commands:
     name: Test All Commands
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -73,7 +73,7 @@ jobs:
 
   integration-test:
     name: Integration Test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code

--- a/examples/github-workflows/.github/workflows/quality.yml
+++ b/examples/github-workflows/.github/workflows/quality.yml
@@ -16,7 +16,7 @@ jobs:
   # Linting with golangci-lint
   lint:
     name: Lint Code
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -36,7 +36,7 @@ jobs:
   # Code formatting check
   format:
     name: Check Formatting
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -61,7 +61,7 @@ jobs:
   # Static analysis
   staticcheck:
     name: Static Analysis
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -81,7 +81,7 @@ jobs:
   # Test coverage check
   coverage:
     name: Test Coverage
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -107,7 +107,7 @@ jobs:
   # Complexity analysis
   complexity:
     name: Complexity Analysis
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code

--- a/examples/github-workflows/.github/workflows/security.yml
+++ b/examples/github-workflows/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
   # CodeQL analysis for security vulnerabilities
   codeql:
     name: CodeQL Analysis
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       actions: read
       contents: read
@@ -55,7 +55,7 @@ jobs:
   # Dependency vulnerability scanning
   dependency-scan:
     name: Dependency Vulnerability Scan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -70,7 +70,7 @@ jobs:
   # Secret scanning (using Trivy)
   secret-scan:
     name: Secret Scanning
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -88,7 +88,7 @@ jobs:
   # SAST (Static Application Security Testing)
   sast:
     name: Static Security Analysis
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code

--- a/examples/github-workflows/.github/workflows/test.yml
+++ b/examples/github-workflows/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     strategy:
       matrix:
@@ -60,7 +60,7 @@ jobs:
   # Integration tests (optional but recommended)
   integration:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: test  # Run after unit tests pass
 
     steps:


### PR DESCRIPTION
Switch all GitHub Actions workflows from ubuntu-latest to self-hosted runner to reduce GitHub runner minute consumption.

- Replaced `runs-on: ubuntu-latest` → `runs-on: self-hosted` in all workflow files
- Preserved matrix builds (`${{ matrix.os }}`) unchanged
- 9 files changed across `.github/workflows/` and `examples/github-workflows/`