### PR TITLE
fix: aggressive project cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ node_modules/
 /structurelint
 dist/
 build/
+target/
 
 # IDE
 .idea/
@@ -43,3 +44,5 @@ repomix-output.txt
 # Test output files
 test-results.txt
 coverage.out
+coverage/
+*.lcov


### PR DESCRIPTION
## Summary

- Added missing `.gitignore` patterns: `target/`, `coverage/`, `*.lcov`
- No tracked generated files found to `git rm --cached`
- No untracked generated files found to delete