### PR TITLE
feat: add goreleaser release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,3 @@ jobs:
         run: goreleaser release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: Homebrew tap push to VidiomTM/homebrew-tap requires a PAT.
-          # GITHUB_TOKEN from Jonathangadeaharder/structurelint cannot write to
-          # the VidiomTM org. Create a PAT with repo scope and store it as
-          # HOMEBREW_TAP_TOKEN secret, then uncomment:
-          # HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,84 +2,28 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    tags: ['v*']
 
 permissions:
   contents: write
 
 jobs:
   release:
-    name: Create Release
-    runs-on: self-hosted
-
+    runs-on: ["self-hosted", "macos", "arm64", "VidiomTM"]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.24'
+      - name: Install goreleaser
+        run: brew install goreleaser
 
-      - name: Run tests
-        run: |
-          go test -v ./... 2>&1 | tee release-test.log
-
-      - name: Upload test logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-test-logs
-          path: release-test.log
-          retention-days: 30
-
-      - name: Build binaries for multiple platforms
-        run: |
-          # Linux amd64
-          echo "Building Linux amd64..." | tee -a release-build.log
-          GOOS=linux GOARCH=amd64 go build -o structurelint-linux-amd64 ./cmd/structurelint 2>&1 | tee -a release-build.log
-
-          # Linux arm64
-          echo "Building Linux arm64..." | tee -a release-build.log
-          GOOS=linux GOARCH=arm64 go build -o structurelint-linux-arm64 ./cmd/structurelint 2>&1 | tee -a release-build.log
-
-          # macOS amd64
-          echo "Building macOS amd64..." | tee -a release-build.log
-          GOOS=darwin GOARCH=amd64 go build -o structurelint-darwin-amd64 ./cmd/structurelint 2>&1 | tee -a release-build.log
-
-          # macOS arm64 (Apple Silicon)
-          echo "Building macOS arm64..." | tee -a release-build.log
-          GOOS=darwin GOARCH=arm64 go build -o structurelint-darwin-arm64 ./cmd/structurelint 2>&1 | tee -a release-build.log
-
-          # Windows amd64
-          echo "Building Windows amd64..." | tee -a release-build.log
-          GOOS=windows GOARCH=amd64 go build -o structurelint-windows-amd64.exe ./cmd/structurelint 2>&1 | tee -a release-build.log
-
-          # Create checksums
-          echo "Creating checksums..." | tee -a release-build.log
-          sha256sum structurelint-* > checksums.txt 2>&1 | tee -a release-build.log
-
-      - name: Upload build logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-build-logs
-          path: release-build.log
-          retention-days: 30
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            structurelint-linux-amd64
-            structurelint-linux-arm64
-            structurelint-darwin-amd64
-            structurelint-darwin-arm64
-            structurelint-windows-amd64.exe
-            checksums.txt
-          generate_release_notes: true
-          draft: false
-          prerelease: false
+      - name: Run goreleaser
+        run: goreleaser release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # TODO: Homebrew tap push to VidiomTM/homebrew-tap requires a PAT.
+          # GITHUB_TOKEN from Jonathangadeaharder/structurelint cannot write to
+          # the VidiomTM org. Create a PAT with repo scope and store it as
+          # HOMEBREW_TAP_TOKEN secret, then uncomment:
+          # HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,45 @@
+version: 2
+
+builds:
+  - main: ./cmd/structurelint
+    binary: structurelint
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}
+      {{- end }}
+
+brews:
+  - name: structurelint
+    repository:
+      owner: VidiomTM
+      name: homebrew-tap
+      branch: main
+    directory: Formula
+    homepage: https://github.com/Jonathangadeaharder/structurelint
+    description: Lint repository structure against a YAML schema
+    test: |
+      system "#{bin}/structurelint --version"
+    install: |
+      bin.install "structurelint"
+
+checksum:
+  name_template: checksums.txt
+
+release:
+  github:
+    owner: Jonathangadeaharder
+    name: structurelint

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,20 +22,6 @@ archives:
       {{- else }}{{ .Arch }}
       {{- end }}
 
-brews:
-  - name: structurelint
-    repository:
-      owner: VidiomTM
-      name: homebrew-tap
-      branch: main
-    directory: Formula
-    homepage: https://github.com/Jonathangadeaharder/structurelint
-    description: Lint repository structure against a YAML schema
-    test: |
-      system "#{bin}/structurelint --version"
-    install: |
-      bin.install "structurelint"
-
 checksum:
   name_template: checksums.txt
 


### PR DESCRIPTION
Replaces the manual `go build` + `softprops/action-gh-release` release workflow with goreleaser.

**Changes:**
- `.goreleaser.yaml`: Goreleaser config building darwin + linux (amd64/arm64), tar.gz archives, Homebrew tap push to VidiomTM/homebrew-tap, checksums
- `.github/workflows/release.yml`: Replaced with goreleaser-based workflow, runs on self-hosted macos arm64 runner

**TODO before first release:**
- Create `HOMEBREW_TAP_TOKEN` secret with a PAT (repo scope) that can write to VidiomTM/homebrew-tap
- Uncomment the `HOMEBREW_TAP_TOKEN` env var in release.yml once the secret exists