### PR TITLE
fix: use GitHub-hosted runner for release, fix goreleaser config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,15 @@ permissions:
 
 jobs:
   release:
-    runs-on: ["self-hosted", "macos", "arm64", "VidiomTM"]
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install goreleaser
-        run: brew install goreleaser
+      - name: Install tree-sitter + goreleaser
+        run: |
+          brew install tree-sitter goreleaser
 
       - name: Run goreleaser
         run: goreleaser release --clean

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,7 +4,7 @@ builds:
   - main: ./cmd/structurelint
     binary: structurelint
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     goos:
       - darwin
       - linux
@@ -27,5 +27,5 @@ checksum:
 
 release:
   github:
-    owner: Jonathangadeaharder
+    owner: VidiomTM
     name: structurelint


### PR DESCRIPTION
Release was failing on self-hosted runners due to missing tree-sitter C libraries.

Changes:
- Switch runs-on from self-hosted to macos-latest (GitHub-hosted)
- Install tree-sitter via brew before goreleaser
- Set CGO_ENABLED=1 (tree-sitter requires CGo)
- Fix release owner from Jonathangadeaharder → VidiomTM