### PR TITLE
fix: add setup-go step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
       - name: Install tree-sitter + goreleaser
         run: |
           brew install tree-sitter goreleaser


### PR DESCRIPTION
GitHub macOS runner doesn't have Go pre-installed. Add actions/setup-go@v5 before goreleaser.