### PR TITLE
fix: remove linux from goreleaser (CGo/tree-sitter can't cross-compile)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,6 @@ builds:
       - CGO_ENABLED=1
     goos:
       - darwin
-      - linux
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
Linux cross-compilation fails because tree-sitter requires CGo and can't be cross-compiled from macOS.\n\nBuild darwin only for now.