### PR TITLE
feat: add fallow-gate rule for SvelteKit projects

### DIFF
--- a/.structurelint.yml
+++ b/.structurelint.yml
@@ -77,6 +77,8 @@ rules:
       - "internal/ptest/**"
       - "fuzz/**"
 
+  ci-gates: true
+  fallow-gate: true
   disallow-import-cycles: true
 
 layers:

--- a/internal/rules/structure/fallow_gate.go
+++ b/internal/rules/structure/fallow_gate.go
@@ -1,0 +1,89 @@
+package structure
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/Jonathangadeaharder/structurelint/internal/rules"
+	"github.com/Jonathangadeaharder/structurelint/internal/walker"
+)
+
+// FallowGateRule validates that a fallow CI gate workflow exists
+// for SvelteKit projects.
+type FallowGateRule struct {
+	rootDir string
+}
+
+// NewFallowGateRule creates a new FallowGateRule.
+func NewFallowGateRule(rootDir string) *FallowGateRule {
+	return &FallowGateRule{rootDir: rootDir}
+}
+
+func (r *FallowGateRule) Name() string { return "fallow-gate" }
+
+func (r *FallowGateRule) Check(files []walker.FileInfo, _ map[string]*walker.DirInfo) []rules.Violation {
+	// Skip if not a SvelteKit project
+	if !r.isSvelteKit(files) {
+		return nil
+	}
+
+	workflowsDir := filepath.Join(r.rootDir, ".github", "workflows")
+
+	if !hasPrefixFile(workflowsDir, "fallow") {
+		return []rules.Violation{
+			{
+				Rule:    r.Name(),
+				Path:    ".github/workflows/fallow.yml",
+				Message: "missing required fallow CI gate for SvelteKit project",
+				Suggestions: []string{
+					"Create .github/workflows/fallow.yml with fallow-rs/fallow@v2 action",
+					"See: https://github.com/fallow-rs/fallow",
+				},
+			},
+		}
+	}
+
+	return nil
+}
+
+// isSvelteKit checks if the project is a SvelteKit project by looking for
+// svelte.config.js/ts or @sveltejs/kit in package.json.
+func (r *FallowGateRule) isSvelteKit(files []walker.FileInfo) bool {
+	hasSvelteConfig := false
+
+	for _, f := range files {
+		name := filepath.Base(f.Path)
+		if name == "svelte.config.js" || name == "svelte.config.ts" {
+			hasSvelteConfig = true
+		}
+		if name == "package.json" && r.hasSvelteKitDependency(f.AbsPath) {
+			return true
+		}
+	}
+
+	return hasSvelteConfig
+}
+
+func (r *FallowGateRule) hasSvelteKitDependency(pkgPath string) bool {
+	data, err := os.ReadFile(pkgPath)
+	if err != nil {
+		return false
+	}
+
+	var pkg struct {
+		Dependencies    map[string]string `json:"dependencies"`
+		DevDependencies map[string]string `json:"devDependencies"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return false
+	}
+
+	if _, ok := pkg.Dependencies["@sveltejs/kit"]; ok {
+		return true
+	}
+	if _, ok := pkg.DevDependencies["@sveltejs/kit"]; ok {
+		return true
+	}
+	return false
+}

--- a/internal/rules/structure/fallow_gate_test.go
+++ b/internal/rules/structure/fallow_gate_test.go
@@ -1,0 +1,121 @@
+package structure
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFallowGate_NonSvelteKit_NoViolations(t *testing.T) {
+	dir := t.TempDir()
+	rule := NewFallowGateRule(dir)
+	files, dirs := walkDir(t, dir)
+
+	v := rule.Check(files, dirs)
+	if len(v) != 0 {
+		t.Fatalf("want 0 violations for non-SvelteKit project, got %d: %+v", len(v), v)
+	}
+}
+
+func TestFallowGate_SvelteKitWithoutFallow_HasViolation(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create svelte.config.js in root
+	writeFile(t, dir, "svelte.config.js", "export default {};\n")
+	// Create .github/workflows dir but no fallow file
+	workflowsDir := filepath.Join(dir, ".github", "workflows")
+	if err := os.MkdirAll(workflowsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .github/workflows: %v", err)
+	}
+	writeFile(t, workflowsDir, "pr-gate.yml", "name: PR Gate\n")
+
+	rule := NewFallowGateRule(dir)
+	files, dirs := walkDir(t, dir)
+	v := rule.Check(files, dirs)
+
+	if len(v) != 1 {
+		t.Fatalf("want 1 violation (fallow missing), got %d: %+v", len(v), v)
+	}
+	if v[0].Path != ".github/workflows/fallow.yml" {
+		t.Fatalf("violation should target fallow.yml, got path=%q", v[0].Path)
+	}
+}
+
+func TestFallowGate_SvelteKitWithFallow_NoViolations(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "svelte.config.js", "export default {};\n")
+	workflowsDir := filepath.Join(dir, ".github", "workflows")
+	if err := os.MkdirAll(workflowsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .github/workflows: %v", err)
+	}
+	writeFile(t, workflowsDir, "fallow.yml", "name: Fallow\n")
+
+	rule := NewFallowGateRule(dir)
+	files, dirs := walkDir(t, dir)
+	v := rule.Check(files, dirs)
+
+	if len(v) != 0 {
+		t.Fatalf("want 0 violations (fallow present), got %d: %+v", len(v), v)
+	}
+}
+
+func TestFallowGate_SvelteKitPackageJSON_DetectsDependency(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create package.json with @sveltejs/kit dependency
+	pkg := `{
+		"name": "test-app",
+		"dependencies": {
+			"@sveltejs/kit": "^2.0.0"
+		}
+	}`
+	writeFile(t, dir, "package.json", pkg)
+
+	rule := NewFallowGateRule(dir)
+	files, dirs := walkDir(t, dir)
+	v := rule.Check(files, dirs)
+
+	if len(v) != 1 {
+		t.Fatalf("want 1 violation (fallow missing, sveltekit detected via package.json), got %d: %+v", len(v), v)
+	}
+}
+
+func TestFallowGate_SvelteKitDevDependency_Detects(t *testing.T) {
+	dir := t.TempDir()
+
+	pkg := `{
+		"name": "test-app",
+		"devDependencies": {
+			"@sveltejs/kit": "^2.0.0"
+		}
+	}`
+	writeFile(t, dir, "package.json", pkg)
+
+	rule := NewFallowGateRule(dir)
+	files, dirs := walkDir(t, dir)
+	v := rule.Check(files, dirs)
+
+	if len(v) != 1 {
+		t.Fatalf("want 1 violation (sveltekit in devDeps), got %d: %+v", len(v), v)
+	}
+}
+
+func TestFallowGate_FallowPrefixMatching(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "svelte.config.ts", "export default {};\n")
+	workflowsDir := filepath.Join(dir, ".github", "workflows")
+	if err := os.MkdirAll(workflowsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .github/workflows: %v", err)
+	}
+	writeFile(t, workflowsDir, "fallow-pr-gate.yml", "name: Fallow PR Gate\n")
+
+	rule := NewFallowGateRule(dir)
+	files, dirs := walkDir(t, dir)
+	v := rule.Check(files, dirs)
+
+	if len(v) != 0 {
+		t.Fatalf("want 0 violations (prefix matched fallow-), got %d: %+v", len(v), v)
+	}
+}

--- a/internal/rules/structure/init.go
+++ b/internal/rules/structure/init.go
@@ -106,6 +106,14 @@ func init() {
 		}
 		return NewDeepRelativeImportsRule(max), nil
 	})
+
+	rules.Register("ci-gates", func(ctx *rules.RuleContext) (rules.Rule, error) {
+		return NewCIGatesRule(ctx.RootDir), nil
+	})
+
+	rules.Register("fallow-gate", func(ctx *rules.RuleContext) (rules.Rule, error) {
+		return NewFallowGateRule(ctx.RootDir), nil
+	})
 }
 
 // parseMaxDepthOverrides accepts:


### PR DESCRIPTION
## Summary

Adds two new config-driven rules:

1. **ci-gates** (registered in registry) — checks for `pr-gate.yml` and `merge-gate.yml` in `.github/workflows/`
2. **fallow-gate** (new) — detects SvelteKit projects via `svelte.config.js/ts` or `@sveltejs/kit` in `package.json`, then requires `fallow.yml` in `.github/workflows/`

The `fallow` CI gate runs `fallow-rs/fallow@v2` audit on every PR, providing codebase intelligence, complexity analysis, and inline review comments.

## Changes

- `internal/rules/structure/fallow_gate.go`: New rule — SvelteKit detection + fallow workflow enforcement
- `internal/rules/structure/fallow_gate_test.go`: 6 tests covering non-SvelteKit, missing fallow, present fallow, package.json detection, devDeps, prefix matching
- `internal/rules/structure/init.go`: Register both `ci-gates` and `fallow-gate` in the registry
- `.structurelint.yml`: Enable both rules for structurelint itself